### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codacy-coverage.yml
+++ b/.github/workflows/codacy-coverage.yml
@@ -2,6 +2,8 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
 name: Codacy Coverage
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/filip26/carbon-did-key/security/code-scanning/3](https://github.com/filip26/carbon-did-key/security/code-scanning/3)

To fix the problem, you should add a `permissions` block to the workflow to explicitly limit the permissions granted to the GITHUB_TOKEN. The best way to do this is to add the block at the root level of the workflow file, just after the `name` and before the `on` key, so it applies to all jobs unless overridden. For this workflow, the minimal required permission is likely `contents: read`, which allows the workflow to read repository contents but not write to them. This change should be made in `.github/workflows/codacy-coverage.yml` by inserting the following block:

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
